### PR TITLE
AMIコスト配分タグのタグ付け自動化。

### DIFF
--- a/ami_backup/aws_backup_image.pl
+++ b/ami_backup/aws_backup_image.pl
@@ -55,9 +55,9 @@ sub create_tags {
 
     if (!defined($ENV{'COST_ALLOCATION_TAG'})) {
         syslog( 'info', "ENV:COST_ALLOCATION_TAG does not defined. processing of create_tag skipped." );
-		return;
+        return;
     }
-	my $tagname = $ENV{'COST_ALLOCATION_TAG'};
+    my $tagname = $ENV{'COST_ALLOCATION_TAG'};
     my $tagvalue = get_tag_value($is, $tagname);
 
     if ($tagvalue ne '') {


### PR DESCRIPTION
コスト配分タグの名称を環境変数（COST_ALLOCATION_TAG）に外だし

他の内容は
https://flt.backlog.jp/view/276ARUHI-3695#comment-1171782057
のタイミングと同様です。